### PR TITLE
Make more useful and usable as an included gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle
 
 config/aws_actual_fffing_secrets.yml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AwsOneClickStaging is a CLI app that will allow you to create a clone of amazon's S3 bucket (named app_name-staging) and the RDS database (named app_name-staging) so your staging server will be 100% up to date with your production server and allow you to perform some serious testing without the fear of losing important files stored on your S3 bucket.  
 
-If you didn't already know, S3 is a file storage solution offered by Amazon, and it's not user friendly so you pretty much need to write/ use a script like this in order to setup a staging server.  RDS is Amazon's database storage.  As with all amazon services, RDS databases are in the clown so you can rely on it working well with your app and working hard to provide your users with hilarious service.  
+If you didn't already know, S3 is a file storage solution offered by Amazon, and it's not user friendly so you pretty much need to write/ use a script like this in order to setup a staging server.  RDS is Amazon's database storage.  As with all amazon services, RDS databases are in the cloud so you can rely on it working well with your app and working hard to provide your users with hilarious service.  
 
 
 ## Installation

--- a/aws_one_click_staging.gemspec
+++ b/aws_one_click_staging.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'aws-sdk', '~> 2'
-  spec.add_dependency "aws-sdk-v1"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/bin/aws_one_click_staging
+++ b/bin/aws_one_click_staging
@@ -6,29 +6,29 @@ require "aws_one_click_staging"
 class AwsOneClickStagingRunner < Thor
   default_task :help
 
-  desc "check", "Checks your ~/.config/aws_one_click_staging.yml for validity"
-  def check
-    AwsOneClickStaging.check
+  desc "check", "Checks your config for validity (default ~/.config/aws_one_click_staging.yml)"
+  def check(file=nil)
+    AwsOneClickStaging.check(file)
   end
 
-  desc "stage", "Makes a copy of the RDS database and the staging server's S3 bucket.  This takes a while.  Run on an Amazon shell!"
-  def stage
-    AwsOneClickStaging.stage
+  desc "stage FILE", "Makes a copy of the RDS database and the staging server's S3 bucket.  This takes a while.  Run on an Amazon shell!"
+  def stage(file=nil)
+    AwsOneClickStaging.stage(file)
   end
 
-  desc "just_rds", "Just clones the RDS part of things."
-  def just_rds
-    AwsOneClickStaging.just_rds
+  desc "just_rds FILE", "Just clones the RDS part of things."
+  def just_rds(file=nil)
+    AwsOneClickStaging.just_rds(file)
   end
 
   desc "just_s3", "Just clones the s3 part of things."
-  def just_s3
-    AwsOneClickStaging.just_s3
+  def just_s3(file=nil)
+    AwsOneClickStaging.just_s3(file)
   end
 
   desc "just_ec2", "Just clones the ec2 part of things."
-  def just_ec2
-    AwsOneClickStaging.just_ec2
+  def just_ec2(file=nil)
+    AwsOneClickStaging.just_ec2(file)
   end
 
   desc "version", "Prints gem's version"

--- a/config/aws_one_click_staging.yml
+++ b/config/aws_one_click_staging.yml
@@ -18,10 +18,12 @@ production:
   account_id:          # the account ID to use when constructing the full snapshot arn
 #  role_arn:            # role to assume to get into production
 
-aws_master_user_password:
 aws_production_bucket: # this bucket is read from
 aws_staging_bucket:    # this bucket is DELETED and written to!
 
 db_instance_id_production: "actioncenter"           # this db_instance is read from
+aws_master_user_password:                           # this is the staging password
 db_instance_id_staging: "actioncenter-staging"      # this db_instance is DELETED and written to!
 db_snapshot_id: "actioncenter-snapshot-for-staging" # this db snapshot id is OVERWRITTEN
+db_staging_options:
+  db_instance_class: "db.t1.micro"

--- a/config/aws_one_click_staging.yml
+++ b/config/aws_one_click_staging.yml
@@ -1,12 +1,23 @@
 # edit these values to match that of your production machine
 # which will be cloned from
 
-# The aws user you set here should only have read access to the production
-# S3 bucket and Db instance to keep your production data safe and happy
-aws_access_key_id:
-aws_secret_access_key:
+# The aws role/credentials you set here should only have read access to the
+# production S3 bucket and DB instance to keep your production data safe and happy
+# If both staging and production are in the same account,
+# there's no need for the staging/production split.
+# Like so:
+#  aws_region: 'us-west-1'
+#  aws_access_key_id: keyid
+#  aws_secret_access_key: accesskey
+staging: &staging
+  aws_region: 'us-west-1'
+  aws_access_key_id:
+  aws_secret_access_key:
+production:
+  <<: *staging
+  account_id:          # the account ID to use when constructing the full snapshot arn
+#  role_arn:            # role to assume to get into production
 
-aws_region: 'us-west-1'
 aws_master_user_password:
 aws_production_bucket: # this bucket is read from
 aws_staging_bucket:    # this bucket is DELETED and written to!

--- a/config/aws_one_click_staging.yml
+++ b/config/aws_one_click_staging.yml
@@ -22,8 +22,14 @@ aws_production_bucket: # this bucket is read from
 aws_staging_bucket:    # this bucket is DELETED and written to!
 
 db_instance_id_production: "actioncenter"           # this db_instance is read from
-aws_master_user_password:                           # this is the staging password
 db_instance_id_staging: "actioncenter-staging"      # this db_instance is DELETED and written to!
 db_snapshot_id: "actioncenter-snapshot-for-staging" # this db snapshot id is OVERWRITTEN
+
+# Will be added to RestoreDBInstanceFromDBSnapshot call
 db_staging_options:
   db_instance_class: "db.t1.micro"
+
+# Will be added to ModifyDBInstance call
+db_staging_modifications:
+  backup_retention_period: 0
+  master_user_password:

--- a/config/aws_one_click_staging.yml
+++ b/config/aws_one_click_staging.yml
@@ -3,13 +3,13 @@
 
 # The aws user you set here should only have read access to the production
 # S3 bucket and Db instance to keep your production data safe and happy
-aws_access_key_id: ""
-aws_secret_access_key: ""
+aws_access_key_id:
+aws_secret_access_key:
 
 aws_region: 'us-west-1'
-aws_master_user_password: ""
-aws_production_bucket: "" # this bucket is read from
-aws_staging_bucket: ""    # this bucket is DELETED and written to!
+aws_master_user_password:
+aws_production_bucket: # this bucket is read from
+aws_staging_bucket:    # this bucket is DELETED and written to!
 
 db_instance_id_production: "actioncenter"           # this db_instance is read from
 db_instance_id_staging: "actioncenter-staging"      # this db_instance is DELETED and written to!

--- a/lib/aws_one_click_staging.rb
+++ b/lib/aws_one_click_staging.rb
@@ -6,8 +6,8 @@ SOURCE_ROOT = File.expand_path("#{File.dirname(__FILE__)}/..")
 
 module AwsOneClickStaging
 
-  def self.stage
-    warrior = AwsWarrior.new
+  def self.stage(file=nil)
+    warrior = AwsWarrior.new(file: file)
     return if warrior.nil?
     puts "cloning database from amazon... this takes a while..."
     warrior.clone_rds
@@ -19,15 +19,17 @@ module AwsOneClickStaging
     puts "\nOperations completed successfully!"
   end
 
-  def self.check
-    warrior = AwsWarrior.new # this makes a config file if needed
+  def self.check(file=nil)
+    warrior = AwsWarrior.new(file: file) # this makes a config file if needed
     puts "This command *would* test that you have the needed permissions on the "
     puts "buckets and rds instances you named in your config file... "
     puts "but alas, you're reading the outputs of a stubbed method..."
+  rescue => e
+    puts e
   end
 
-  def self.just_s3
-    warrior = AwsWarrior.new
+  def self.just_s3(file=nil)
+    warrior = AwsWarrior.new(file: file)
     return if warrior.nil?
 
     puts "cloning s3 bucket from amazon... this takes forever..."
@@ -36,8 +38,8 @@ module AwsOneClickStaging
 
   end
 
-  def self.just_rds
-    warrior = AwsWarrior.new
+  def self.just_rds(file=nil)
+    warrior = AwsWarrior.new(file: file)
     return if warrior.nil?
 
     puts "cloning database from amazon... this takes a while..."
@@ -48,8 +50,8 @@ module AwsOneClickStaging
     puts "\nOperations completed successfully!"
   end
 
-  def self.just_ec2
-    warrior = AwsWarrior.new
+  def self.just_ec2(file=nil)
+    warrior = AwsWarrior.new(file: file)
     puts "this is a stub because we only did this one time and don't feel need to repeat."
   end
 

--- a/lib/aws_one_click_staging.rb
+++ b/lib/aws_one_click_staging.rb
@@ -14,7 +14,7 @@ module AwsOneClickStaging
     puts "cloning s3 bucket from amazon... this takes forever..."
     warrior.clone_s3_bucket
 
-    puts warrior.get_fancy_string_of_staging_db_uri
+    pretty_print_staging_db_uri(warrior)
 
     puts "\nOperations completed successfully!"
   end
@@ -45,7 +45,7 @@ module AwsOneClickStaging
     puts "cloning database from amazon... this takes a while..."
     warrior.clone_rds
 
-    puts warrior.get_fancy_string_of_staging_db_uri
+    pretty_print_staging_db_uri(warrior)
 
     puts "\nOperations completed successfully!"
   end
@@ -55,4 +55,14 @@ module AwsOneClickStaging
     puts "this is a stub because we only did this one time and don't feel need to repeat."
   end
 
+  def self.pretty_print_staging_db_uri(warrior)
+    l = 66
+    msg = ""
+    msg += "*" * l + "\n"
+    msg += "* "
+    msg += warrior.get_fancy_string_of_staging_db_uri
+    msg += "  *\n"
+    msg += "*" * l
+    puts msg
+  end
 end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -152,8 +152,7 @@ module AwsOneClickStaging
         db_instance_identifier: @db_instance_id_staging,
         db_snapshot_identifier: db_snapshot_id,
       )
-      response = @c_staging.restore_db_instance_from_db_snapshot(options)
-
+      @c_staging.restore_db_instance_from_db_snapshot(options)
 
       sleep 10 while get_fresh_db_instance_state(@db_instance_id_staging).db_instance_status != "available"
 
@@ -162,7 +161,7 @@ module AwsOneClickStaging
           db_instance_identifier: @db_instance_id_staging,
           apply_immediately: true # will happen during the next maintenance window otherwise
         )
-        response = @c_staging.modify_db_instance(modifications)
+        @c_staging.modify_db_instance(modifications)
         sleep 2 until db_instance_ready?(@db_instance_id_staging)
       end
     end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -151,11 +151,11 @@ module AwsOneClickStaging
                        else
                          @db_snapshot_id
                        end
-      response = @c_staging.restore_db_instance_from_db_snapshot(
+      options = @config['db_staging_options'].to_h.merge(
         db_instance_identifier: @db_instance_id_staging,
         db_snapshot_identifier: db_snapshot_id,
-        db_instance_class: "db.t1.micro"
       )
+      response = @c_staging.restore_db_instance_from_db_snapshot(options)
 
 
       sleep 10 while get_fresh_db_instance_state(@db_instance_id_staging).db_instance_status != "available"

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -1,17 +1,16 @@
-require 'fileutils'
+require "aws_one_click_staging/config_file"
 require 'aws-sdk'
-require 'yaml'
 
 module AwsOneClickStaging
 
   class AwsWarrior
 
-    def initialize
-      # read config file
-      @config_dir = "#{ENV['HOME']}/.config"
-      @config_file = File.expand_path("#{@config_dir}/aws_one_click_staging.yml")
-      return nil if create_config_file_if_needed!
-      @config = YAML.load(read_config_file)
+    def initialize file: nil, config: nil
+      if config
+        @config = config
+      else
+        @config = ConfigFile.load(file)
+      end
       setup_aws_credentials_and_configs
     end
 
@@ -146,30 +145,6 @@ module AwsOneClickStaging
     rescue Aws::RDS::Errors::DBInstanceNotFound => e
       true
     end
-
-
-
-
-    def read_config_file
-      config = File.read(@config_file)
-    end
-
-    def create_config_file_if_needed!
-      return false if File.exists?(@config_file)
-      msg = ""
-      msg += "Config file not found, creating...\n\n"
-
-      # copy example config file to config file path
-      FileUtils.mkdir_p @config_dir
-      FileUtils.cp("#{SOURCE_ROOT}/config/aws_one_click_staging.yml", @config_file)
-
-      msg += "An empty config file was created for you in #{@config_file}\n"
-      msg += "Please populate it with the correct information and run this \n"
-      msg += "command again.  \n"
-
-      true
-    end
-
   end
 
 end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -19,9 +19,16 @@ module AwsOneClickStaging
     end
 
     def clone_rds
+      recreate_snapshot
+      recreate_staging_db_instance
+    end
+
+    def recreate_snapshot
       delete_snapshot_for_staging!
       create_new_snapshot_for_staging!
+    end
 
+    def recreate_staging_db_instance
       delete_staging_db_instance!
       spawn_new_staging_db_instance!
     end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -40,14 +40,7 @@ module AwsOneClickStaging
     end
 
     def get_fancy_string_of_staging_db_uri
-      l = 66
-      msg = ""
-      msg += "*" * l + "\n"
-      msg += "* "
-      msg += get_fresh_db_instance_state(@db_instance_id_staging).endpoint.address
-      msg += "  *\n"
-      msg += "*" * l
-      msg
+      get_fresh_db_instance_state(@db_instance_id_staging).endpoint.address
     end
 
     private

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -95,7 +95,7 @@ module AwsOneClickStaging
 
     def create_new_snapshot_for_staging!
       puts "creating new snapshot... this takes like 170 seconds..."
-      response = @c.create_db_snapshot({db_instance_identifier: @db_instance_id_production,
+      @c.create_db_snapshot({db_instance_identifier: @db_instance_id_production,
         db_snapshot_identifier: @db_snapshot_id })
 
       sleep 10 while get_fresh_db_snapshot_state.status != "available"
@@ -107,7 +107,7 @@ module AwsOneClickStaging
 
     def delete_staging_db_instance!
       puts "Deleting old staging instance... This one's a doozy =/"
-      response = @c.delete_db_instance(db_instance_identifier: @db_instance_id_staging,
+      @c.delete_db_instance(db_instance_identifier: @db_instance_id_staging,
         skip_final_snapshot: true)
 
       sleep 10 until db_instance_is_deleted?(@db_instance_id_staging)
@@ -151,7 +151,7 @@ module AwsOneClickStaging
     def db_instance_is_deleted?(db_instance_id)
       @c.describe_db_instances(db_instance_identifier: db_instance_id).db_instances.first
       false
-    rescue Aws::RDS::Errors::DBInstanceNotFound => e
+    rescue Aws::RDS::Errors::DBInstanceNotFound
       true
     end
   end

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -162,7 +162,7 @@ module AwsOneClickStaging
           apply_immediately: true # will happen during the next maintenance window otherwise
         )
         @c_staging.modify_db_instance(modifications)
-        sleep 2 until db_instance_ready?(@db_instance_id_staging)
+        sleep 10 until db_instance_ready?(@db_instance_id_staging)
       end
     end
 

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -165,10 +165,14 @@ module AwsOneClickStaging
           apply_immediately: true # will happen during the next maintenance window otherwise
         )
         response = @c_staging.modify_db_instance(modifications)
-        sleep 2 while get_fresh_db_instance_state(@db_instance_id_staging).db_instance_status != "available"
+        sleep 2 until db_instance_ready?(@db_instance_id_staging)
       end
     end
 
+    def db_instance_ready?(db_instance_id)
+      instance_state = get_fresh_db_instance_state(db_instance_id)
+      instance_state.db_instance_status == "available" && instance_state.pending_modified_values.empty?
+    end
 
     # we use this methods cause amazon lawl-pain
     def get_fresh_db_snapshot_state

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -143,8 +143,6 @@ module AwsOneClickStaging
     def spawn_new_staging_db_instance!
       puts "Spawning a new fully clony RDS db instance for staging purposes"
 
-      @c_production.describe_db_snapshots(db_snapshot_identifier: @db_snapshot_id).db_snapshots.first
-
       db_snapshot_id = if @config["production"]
                          "arn:aws:rds:#{Aws.config[:region]}:#{@config["production"]["account_id"]}:snapshot:#{@db_snapshot_id}"
                        else

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -181,7 +181,7 @@ module AwsOneClickStaging
     end
 
     def db_instance_is_deleted?(db_instance_id)
-      @c_staging.describe_db_instances(db_instance_identifier: db_instance_id).db_instances.first
+      get_fresh_db_instance_state(db_instance_id)
       false
     rescue Aws::RDS::Errors::DBInstanceNotFound
       true

--- a/lib/aws_one_click_staging/aws_warrior.rb
+++ b/lib/aws_one_click_staging/aws_warrior.rb
@@ -131,10 +131,6 @@ module AwsOneClickStaging
           values_to_add: [Aws::STS::Client.new(@staging_creds).get_caller_identity.account]
         )
       end
-
-      true
-    rescue
-      false
     end
 
     def delete_staging_db_instance!

--- a/lib/aws_one_click_staging/config_file.rb
+++ b/lib/aws_one_click_staging/config_file.rb
@@ -1,0 +1,40 @@
+require 'fileutils'
+require 'yaml'
+
+module AwsOneClickStaging
+
+  class ConfigFile
+    class NewFileError < RuntimeError
+    end
+
+    def self.load(file=nil)
+      file ||= default_file
+      return nil if create_if_needed!(file)
+      YAML.load_file(file)
+    end
+
+    def self.create_if_needed!(file)
+      return false if File.exists?(file)
+
+      puts "Config file not found, creating...\n\n"
+      create!(file)
+
+      msg = ""
+      msg += "An empty config file was created for you in #{file}\n"
+      msg += "Please populate it with the correct information and run this \n"
+      msg += "command again.\n"
+      raise NewFileError, msg
+    end
+
+    def self.default_file
+      dir = "#{ENV['HOME']}/.config"
+      File.expand_path("#{dir}/aws_one_click_staging.yml")
+    end
+
+    # copy example config file to config file path
+    def self.create!(file=default_file)
+      FileUtils.mkdir_p File.dirname(file)
+      FileUtils.cp("#{SOURCE_ROOT}/config/aws_one_click_staging.yml", file)
+    end
+  end
+end

--- a/spec/aws_one_click_staging_spec.rb
+++ b/spec/aws_one_click_staging_spec.rb
@@ -25,7 +25,12 @@ describe AwsOneClickStaging do
 
     before :each do
       config = AwsOneClickStaging::ConfigFile.load
+      # for testing without AWS accounts
       config.each_key {|key| config[key] = 'nonsense' if !config[key]}
+      ['staging', 'production'].each do |scope|
+        hash = config[scope].to_h
+        hash.each_key {|key| hash[key] = 'nonsense' if !hash[key]}
+      end
       @aws_warrior = AwsOneClickStaging::AwsWarrior.new(config: config)
     end
 

--- a/spec/aws_one_click_staging_spec.rb
+++ b/spec/aws_one_click_staging_spec.rb
@@ -13,9 +13,9 @@ describe AwsOneClickStaging do
   end
 
   it 'can check config files' do
-    a = AwsOneClickStaging.check
+    expect{AwsOneClickStaging::AwsWarrior.new(file: "#{@mocked_home}/aws_one_click_staging.yml")}.to raise_error(AwsOneClickStaging::ConfigFile::NewFileError)
 
-    expect(File.exists?("#{ENV['HOME']}/.config/aws_one_click_staging.yml")).to be true
+    expect(File.exists?("#{ENV['HOME']}/aws_one_click_staging.yml")).to be true
   end
 
 

--- a/spec/aws_one_click_staging_spec.rb
+++ b/spec/aws_one_click_staging_spec.rb
@@ -16,13 +16,17 @@ describe AwsOneClickStaging do
     expect{AwsOneClickStaging::AwsWarrior.new(file: "#{@mocked_home}/aws_one_click_staging.yml")}.to raise_error(AwsOneClickStaging::ConfigFile::NewFileError)
 
     expect(File.exists?("#{ENV['HOME']}/aws_one_click_staging.yml")).to be true
+
+    expect{AwsOneClickStaging::AwsWarrior.new(file: "#{@mocked_home}/aws_one_click_staging.yml")}.to raise_error(AwsOneClickStaging::AwsWarrior::BadConfiguration)
   end
 
 
   describe 'AwsWarrior' do
 
     before :each do
-      @aws_warrior = AwsOneClickStaging::AwsWarrior.new
+      config = AwsOneClickStaging::ConfigFile.load
+      config.each_key {|key| config[key] = 'nonsense' if !config[key]}
+      @aws_warrior = AwsOneClickStaging::AwsWarrior.new(config: config)
     end
 
     it 'can clone an RDS database' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,5 +16,7 @@ def reset_test_env
   working_amazon_credentials_file = "#{SOURCE_ROOT}/config/aws_actual_fffing_secrets.yml"
   if File.exists?(working_amazon_credentials_file)
     FileUtils.cp(working_amazon_credentials_file, "#{@mocked_home}/.config/aws_one_click_staging.yml")
+  else
+    AwsOneClickStaging::ConfigFile.create!
   end
 end


### PR DESCRIPTION
Hi,

This pull includes many changes we needed to use the code, so here's a summary:
- switch to AWS SDK v2.
- possibility to use configuration files or hashes as input.
- extraction of all DB parameters into input, so it'll be possible to set much more about what kind of DB machine you get.
- added an option to use a separate account for production DB (requires some cross-account setup in AWS)